### PR TITLE
[bugfix] deepflow querier datasource, when using 'INTERVAL' only, tim…

### DIFF
--- a/deepflow-querier-datasource/src/datasource.ts
+++ b/deepflow-querier-datasource/src/datasource.ts
@@ -302,7 +302,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
                   }
                 }
                 return {
-                  name: [keyPrefix, ...(queryData.showMetrics ? [key] : [])].join('-'),
+                  name: [keyPrefix || '*', ...(queryData.showMetrics ? [key] : [])].join('-'),
                   type: type
                 }
               })
@@ -312,7 +312,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
           item.forEach((e, i) => {
             _.forIn(e, (val, key) => {
               if (returnMetricNames.includes(key)) {
-                const keyName = [keyPrefix, ...(queryData.showMetrics ? [key] : [])].join('-')
+                const keyName = [keyPrefix || '*', ...(queryData.showMetrics ? [key] : [])].join('-')
                 e[keyName] = val
               }
             })


### PR DESCRIPTION
…e series can't display

**Phenomenon and reproduction steps**

none

**Root cause and solution**

none

**Impactions**

- deepflow querier datasource
- select one time in 'INTERVAL'
- select one metrics in 'SELECT'
- choose time series panel
- default label keyPrefix is '*'

**Test method**

none

**Affected branch(es)**

- main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)