### PR TITLE
[bugfix] deepflow querier datasource, tag from 'SELECT' can't load va…

### DIFF
--- a/deepflow-querier-datasource/src/components/TagValueSelector.tsx
+++ b/deepflow-querier-datasource/src/components/TagValueSelector.tsx
@@ -3,7 +3,7 @@ import { Select, Input, AsyncSelect } from '@grafana/ui'
 import { LabelItem, SelectOpts } from 'QueryEditor'
 import _ from 'lodash'
 import * as querierJs from 'deepflow-sdk-js'
-import { genGetTagValuesSql } from 'utils/tools'
+import { genGetTagValuesSql, getRealKey } from 'utils/tools'
 import { getTagMapCache } from 'utils/cache'
 
 export const INPUT_TAG_VAL_TYPES = ['int', 'ip', 'mac', 'ip_array']
@@ -47,7 +47,8 @@ export const TagValueSelector = (props: {
       return []
     }
 
-    const tagMapItem = getTagMapCache(db, from, basicData.key)
+    const tagMapItem = getTagMapCache(db, from, getRealKey(basicData))
+
     let opts = []
     try {
       // @ts-ignore


### PR DESCRIPTION
…lue options

**Phenomenon and reproduction steps**

none

**Root cause and solution**

none

**Impactions**

none

**Test method**

- deepflow querier datsource
- choose a tag from 'SELECT' in 'WHERE'
- choose '=' operator
- open value selector, options loaded auto by api request

**Affected branch(es)**

- main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)