### PR TITLE
[bugfix] deepflow querier datasource, 'SHOW METRICS' display wrong in…

### DIFF
--- a/deepflow-querier-datasource/src/QueryEditor.tsx
+++ b/deepflow-querier-datasource/src/QueryEditor.tsx
@@ -1233,7 +1233,12 @@ export class QueryEditor extends PureComponent<Props> {
                             />
                           </InlineField>
                           <InlineField className="custom-label" label="SHOW METRICS" labelWidth={14}>
-                            <div>
+                            <div
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center'
+                              }}
+                            >
                               <Select
                                 options={showMetricsOpts}
                                 value={this.state.showMetrics}


### PR DESCRIPTION
… grafana 8.x

**Phenomenon and reproduction steps**

none

**Root cause and solution**

none

**Impactions**

none

**Test method**

none

**Affected branch(es)**

- main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)